### PR TITLE
Remove mpi4py dependency and add h5py fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Mesh converter from Exodus2 to XDMF"
 authors = [{ name = "Jørgen S. Dokken", email = "dokken@simula.no" }]
 license = { file = "LICENSE" }
 readme = "README.md"
-dependencies = ["adios2", "netCDF4", "mpi4py", "h5py"]
+dependencies = ["adios2", "netCDF4", "h5py"]
 
 [project.optional-dependencies]
 test = ["pytest", "coverage"]

--- a/src/mesh_converter/exodus2_converter.py
+++ b/src/mesh_converter/exodus2_converter.py
@@ -192,10 +192,12 @@ def read_exodus2_data(filename: str | Path) -> Mesh:
         infile.close()
     # Convert topology data into adjacency list
     topology_data = connectivity_array.reshape(-1).astype(np.int32)
-    topology_offset = np.arange(connectivity_array.shape[0]+1) * connectivity_array.shape[1]
+    topology_offset = (
+        np.arange(connectivity_array.shape[0] + 1) * connectivity_array.shape[1]
+    )
     # Convert facet topology into adjacency list
     facet_topology_data = sub_geometry.reshape(-1)
-    facet_topology_offset = np.arange(sub_geometry.shape[0]+1) * sub_geometry.shape[1]
+    facet_topology_offset = np.arange(sub_geometry.shape[0] + 1) * sub_geometry.shape[1]
     return Mesh(
         geometry=coordinates,
         topology_array=topology_data,

--- a/src/mesh_converter/vtk.py
+++ b/src/mesh_converter/vtk.py
@@ -66,6 +66,7 @@ def write(mesh: Mesh, filename: str | Path):
     """
     try:
         from mpi4py import MPI
+
         comm = MPI.COMM_WORLD
         assert comm.size == 1, "Only serial writing supported"
         fname = Path(filename).with_suffix(".vtkhdf")
@@ -128,6 +129,6 @@ def write(mesh: Mesh, filename: str | Path):
     if len(mesh.cell_values) > 0:
         cv = hdf.create_group("CellData")
         cv.attrs["Scalars"] = ["Cell_Markers"]
-        cv.create_dataset("Cell_Markers", shape=(num_cells, ), data=mesh.cell_values)
+        cv.create_dataset("Cell_Markers", shape=(num_cells,), data=mesh.cell_values)
 
     inf.close()

--- a/src/mesh_converter/vtk.py
+++ b/src/mesh_converter/vtk.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from mpi4py import MPI
 import h5py
 import numpy as np
 from mesh_converter import Mesh, CellType
@@ -65,23 +64,28 @@ def write(mesh: Mesh, filename: str | Path):
     """
     Write mesh to VTK HDF5 format
     """
-    comm = MPI.COMM_WORLD
-    assert comm.size == 1, "Only serial writing supported"
-    fname = Path(filename).with_suffix(".vtkhdf")
-    inf = h5py.File(fname, "w", driver="mpio", comm=comm)
-
-    metadata = inf.create_group(np.string_("Metadata"))
+    try:
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        assert comm.size == 1, "Only serial writing supported"
+        fname = Path(filename).with_suffix(".vtkhdf")
+        inf = h5py.File(fname, "w", driver="mpio", comm=comm)
+    except ImportError:
+        inf = h5py.File(filename, "w")
+    except ValueError:
+        inf = h5py.File(filename, "w")
+    metadata = inf.create_group(np.bytes_("Metadata"))
     metadata.attrs["gdim"] = mesh.geometry.shape[1]
-    hdf = inf.create_group(np.string_("VTKHDF"))
+    hdf = inf.create_group(np.bytes_("VTKHDF"))
     h5py.string_dtype(encoding="ascii")
     hdf.attrs["Version"] = [2, 2]
-    hdf.attrs["Type"] = np.string_("UnstructuredGrid")
+    hdf.attrs["Type"] = np.bytes_("UnstructuredGrid")
     global_shape = mesh.geometry.shape
     gdtype = mesh.geometry.dtype
 
     padded_geometry = np.zeros((global_shape[0], 3), dtype=gdtype)
     padded_geometry[:, : global_shape[1]] = mesh.geometry
-    p_string = np.string_("Points")
+    p_string = np.bytes_("Points")
     geom_set = hdf.create_dataset(p_string, padded_geometry.shape, dtype=gdtype)
     geom_set[:, :] = padded_geometry
 

--- a/src/mesh_converter/xdmf.py
+++ b/src/mesh_converter/xdmf.py
@@ -1,5 +1,4 @@
-from mpi4py import MPI
-
+from __future__ import annotations
 import adios2
 from pathlib import Path
 import xml.etree.ElementTree as ET
@@ -7,6 +6,10 @@ from enum import Enum
 from .mesh import Mesh, CellType, cell_to_facet
 import numpy as np
 import numpy.typing as npt
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    import h5py
 
 __all__ = ["write", "XDMFCellType"]
 
@@ -91,6 +94,83 @@ def define_topology(
     it0.text = f"{filename.stem}.h5:/Step0/Connectivity_{str(cell_type)}"
 
 
+def write_mesh_data_adios2(mesh: Mesh, io: adios2.IO, outfile: adios2.Engine):
+    """
+    Write mesh data to ADIOS2 file
+
+    :param mesh: The mesh
+    :param io: The IO instance
+    :param outfile: The outfile instance
+    """
+    pointvar = io.DefineVariable(
+        "Points",
+        mesh.geometry,
+        shape=[mesh.geometry.shape[0], mesh.geometry.shape[1]],
+        start=[0, 0],
+        count=[mesh.geometry.shape[0], mesh.geometry.shape[1]],
+    )
+    outfile.Put(pointvar, mesh.geometry)  # type: ignore
+    top_shape = extract_shape(mesh.topology_offset)
+    top_data = mesh.topology_array.reshape(*top_shape)
+    topology_var = io.DefineVariable(
+        f"Connectivity_{str(mesh.cell_types[0])}",
+        top_data,
+        shape=[top_shape[0], top_shape[1]],
+        start=[0, 0],
+        count=[top_shape[0], top_shape[1]],
+    )
+    outfile.Put(topology_var, top_data)  # type: ignore
+
+    facet_top_shape = extract_shape(mesh.facet_topology_offset)
+    facet_top_data = mesh.facet_topology_array.reshape(*facet_top_shape)
+    facet_topology_var = io.DefineVariable(
+        f"Connectivity_{str(cell_to_facet[mesh.cell_types[0]])}",
+        facet_top_data,
+        shape=[facet_top_shape[0], facet_top_shape[1]],
+        start=[0, 0],
+        count=[facet_top_shape[0], facet_top_shape[1]],
+    )
+    outfile.Put(facet_topology_var, facet_top_data)  # type: ignore
+
+    if len(mesh.cell_values) > 0:
+        cell_values_var = io.DefineVariable(
+            "Cell_Markers",
+            mesh.cell_values,
+            shape=[mesh.cell_values.shape[0]],
+            start=[0],
+            count=[mesh.cell_values.shape[0]],
+        )
+        outfile.Put(cell_values_var, mesh.cell_values)  # type: ignore
+
+    if len(mesh.facet_values) > 0:
+        facet_values_var = io.DefineVariable(
+            "Facet_Markers",
+            mesh.facet_values,
+            shape=[mesh.facet_values.shape[0]],
+            start=[0],
+            count=[mesh.facet_values.shape[0]],
+        )
+        outfile.Put(facet_values_var, mesh.facet_values)  # type: ignore
+
+def write_mesh_data_h5py(mesh: Mesh, outfile: h5py.File):
+    """Write mesh data using h5py
+
+    :param mesh: Mesh to write to file
+    :param outfile: H5py file object
+    """
+    step = outfile.create_group(np.bytes_("Step0"))
+    step.create_dataset("Points", data=mesh.geometry)
+    top_shape = extract_shape(mesh.topology_offset)
+    top_data = mesh.topology_array.reshape(*top_shape)
+    step.create_dataset(f"Connectivity_{str(mesh.cell_types[0])}", data=top_data)
+    facet_top_shape = extract_shape(mesh.facet_topology_offset)
+    facet_top_data = mesh.facet_topology_array.reshape(*facet_top_shape)
+    step.create_dataset(f"Connectivity_{str(cell_to_facet[mesh.cell_types[0]])}", data=facet_top_data)
+    if len(mesh.cell_values) > 0:
+        step.create_dataset("Cell_Markers", data=mesh.cell_values)
+    if len(mesh.facet_values) > 0:
+        step.create_dataset("Facet_Markers", data=mesh.facet_values)
+
 def write(mesh: Mesh, filename: str | Path):
     """
     Write mesh to XDMF format
@@ -165,61 +245,41 @@ def write(mesh: Mesh, filename: str | Path):
         outfile.write(ET.tostring(xdmf, encoding="unicode"))
 
     # Create ADIOS2 writer
-    assert MPI.COMM_WORLD.size == 1, "Mesh convert only works in serial for now"
-    adios = adios2.ADIOS(MPI.COMM_WORLD)
+    try:
+        from mpi4py import MPI
+        assert MPI.COMM_WORLD.size == 1, "Mesh convert only works in serial for now"
+        adios = adios2.ADIOS(MPI.COMM_WORLD)
+    except ImportError:
+        adios = adios2.ADIOS()
+    except TypeError:
+        adios = adios2.ADIOS()
+
     io = adios.DeclareIO("Mesh writer")
     io.SetEngine("HDF5")
-    outfile = io.Open(str(filename.with_suffix(".h5")), adios2.Mode.Write)
-    pointvar = io.DefineVariable(
-        "Points",
-        mesh.geometry,
-        shape=[mesh.geometry.shape[0], mesh.geometry.shape[1]],
-        start=[0, 0],
-        count=[mesh.geometry.shape[0], mesh.geometry.shape[1]],
-    )
-    outfile.Put(pointvar, mesh.geometry)  # type: ignore
-    top_shape = extract_shape(mesh.topology_offset)
-    top_data = mesh.topology_array.reshape(*top_shape)
-    topology_var = io.DefineVariable(
-        f"Connectivity_{str(mesh.cell_types[0])}",
-        top_data,
-        shape=[top_shape[0], top_shape[1]],
-        start=[0, 0],
-        count=[top_shape[0], top_shape[1]],
-    )
-    outfile.Put(topology_var, top_data)  # type: ignore
+    fname = Path(filename).with_suffix(".h5")
+    try:    
+        outfile = io.Open(str(fname), adios2.Mode.Write)
+        write_mesh_data_adios2(mesh, io, outfile)
+        outfile.PerformPuts()  # type: ignore
+        outfile.Close()  # type: ignore
+        assert adios.RemoveIO("Mesh writer")
 
-    facet_top_shape = extract_shape(mesh.facet_topology_offset)
-    facet_top_data = mesh.facet_topology_array.reshape(*facet_top_shape)
-    facet_topology_var = io.DefineVariable(
-        f"Connectivity_{str(cell_to_facet[mesh.cell_types[0]])}",
-        facet_top_data,
-        shape=[facet_top_shape[0], facet_top_shape[1]],
-        start=[0, 0],
-        count=[facet_top_shape[0], facet_top_shape[1]],
-    )
-    outfile.Put(facet_topology_var, facet_top_data)  # type: ignore
+    except ValueError:
+        # Fallback to h5py
 
-    if len(mesh.cell_values) > 0:
-        cell_values_var = io.DefineVariable(
-            "Cell_Markers",
-            mesh.cell_values,
-            shape=[mesh.cell_values.shape[0]],
-            start=[0],
-            count=[mesh.cell_values.shape[0]],
-        )
-        outfile.Put(cell_values_var, mesh.cell_values)  # type: ignore
+        try:
+            import h5py
+        except ImportError:
+            raise ValueError("ADIOS2 with HDF5 support and h5py not available, cannot write mesh")
+        try:
+            from mpi4py import MPI
+            comm = MPI.COMM_WORLD
+            assert comm.size == 1, "Only serial writing supported"
+            inf = h5py.File(fname, "w", driver="mpio", comm=comm)
+        except ImportError:
+            inf = h5py.File(fname, "w")
+        except ValueError:
+            inf = h5py.File(fname, "w")
 
-    if len(mesh.facet_values) > 0:
-        facet_values_var = io.DefineVariable(
-            "Facet_Markers",
-            mesh.facet_values,
-            shape=[mesh.facet_values.shape[0]],
-            start=[0],
-            count=[mesh.facet_values.shape[0]],
-        )
-        outfile.Put(facet_values_var, mesh.facet_values)  # type: ignore
-
-    outfile.PerformPuts()  # type: ignore
-    outfile.Close()  # type: ignore
-    assert adios.RemoveIO("Mesh writer")
+        write_mesh_data_h5py(mesh, inf)
+        inf.close()


### PR DESCRIPTION
Support serial version of ADIOS2 (still not the pypi one as it does not build with hdf5 support).
Add fallback to h5py for writing the same HDF5 file (both serial and parallel version).